### PR TITLE
fix: do not listen port for https if no ssl configured

### DIFF
--- a/rootfs/etc/nginx/template/nginx.tmpl
+++ b/rootfs/etc/nginx/template/nginx.tmpl
@@ -886,7 +886,9 @@ stream {
         {{ $server := .Second }}
 
         {{ buildHTTPListener  $all $server.Hostname }}
+        {{ if $server.SSLCert }}
         {{ buildHTTPSListener $all $server.Hostname }}
+        {{ end }}
 
         set $proxy_upstream_name "-";
 


### PR DESCRIPTION
fix regression caused by https://github.com/kubernetes/ingress-nginx/pull/4439

<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
when creating an ingress without ssl cert, nginx will still listen on 442 for the server, which is not expected.
what we got:
```
                listen 80  ;
		listen [::]:80  ;

		listen 442 proxy_protocol  ssl http2 ;
		listen [::]:442 proxy_protocol  ssl http2 ;
```
what we expect:
```
                listen 80  ;
		listen [::]:80  ;
```

<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/master/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
